### PR TITLE
Add action to war task to produce exploded war

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -11,11 +11,6 @@ springBoot {
     mainClass = 'testme.CasWebApplication'
 }
 
-//A helper to produce an exploded war, should one choose to use it
-war.doLast {
-    ant.unzip(src: war.archivePath, dest: "$buildDir/cas")
-}
-
 task wrapper(type: Wrapper) {
     gradleVersion = 2.12
 }

--- a/build.gradle
+++ b/build.gradle
@@ -11,6 +11,11 @@ springBoot {
     mainClass = 'testme.CasWebApplication'
 }
 
+//A helper to produce an exploded war, should one choose to use it
+war.doLast {
+    ant.unzip(src: war.archivePath, dest: "$buildDir/cas")
+}
+
 task wrapper(type: Wrapper) {
     gradleVersion = 2.12
 }

--- a/gradle/cas.gradle
+++ b/gradle/cas.gradle
@@ -18,3 +18,10 @@ repositories {
 dependencies {
     compile "com.fasterxml:classmate:1.3.0"
 }
+
+task explodeWar(type: Copy) {
+    group = "build"
+    description = "explode the war"
+    from zipTree(project.war.outputs.files.singleFile)
+    into "${buildDir}/cas"
+}


### PR DESCRIPTION
This is very convenient for folks (myself for example) to develop and deploy exploded war. I add this `war` task's action manually in EVERY Gradle project. Tired of repeating myself, so this would be a great feature to come out of the box.
